### PR TITLE
Update guideline.md

### DIFF
--- a/docs/guideline.md
+++ b/docs/guideline.md
@@ -63,8 +63,8 @@ We decided to use the monorepo structure with submodules to achieve the followin
 When getting started for the first time run the following:
 
 ```bash
-git clone https://github.com/block-wallet/extension
-cd extension
+git clone https://github.com/block-wallet/block-extension
+cd block-extension
 git submodule update --init --recursive
 make git/branch/checkout BRANCH=master
 ```


### PR DESCRIPTION
Current git clone tutorial links to 'extension' instead of 'block-extension'